### PR TITLE
making the OpenSSL calls in sigh thread save

### DIFF
--- a/src/milter.cpp
+++ b/src/milter.cpp
@@ -678,6 +678,7 @@ int main(int argc, const char *argv[]) {
             std::cerr << "Error: Unable to create PID file" << std::endl;
         out.close();
     }
+    init_openssl();
 
     // Define headers
     ::header.push_back(mlt_header_name);
@@ -704,6 +705,8 @@ int main(int argc, const char *argv[]) {
 
     // Wait for signals
     milter.join();
+
+    deinit_openssl();
 
     if (!mfpidfile.empty()) {
         try {

--- a/src/smime.cpp
+++ b/src/smime.cpp
@@ -12,6 +12,7 @@
 
 #include <openssl/pkcs7.h>
 #include <openssl/err.h>
+#include <pthread.h>
 #include <syslog.h>
 
 #include <string>
@@ -22,6 +23,67 @@
 #include "common.h"
 #include "client.h"
 #include "mapfile.h"
+
+/* we have this global to let the callback get easy access to it */
+static pthread_mutex_t *lockarray;
+
+static void lock_callback(int mode, int type, char *file, int line)
+{
+  (void)file;
+  (void)line;
+  if (mode & CRYPTO_LOCK) {
+    pthread_mutex_lock(&(lockarray[type]));
+  }
+  else {
+    pthread_mutex_unlock(&(lockarray[type]));
+  }
+}
+
+static unsigned long thread_id(void)
+{
+  unsigned long ret;
+
+  ret=(unsigned long)pthread_self();
+  return(ret);
+}
+
+void init_openssl(void)
+{
+    int i;
+
+    // initialize lock array
+    lockarray=(pthread_mutex_t *)OPENSSL_malloc(CRYPTO_num_locks() *
+                                          sizeof(pthread_mutex_t));
+    for (i=0; i<CRYPTO_num_locks(); i++) {
+        pthread_mutex_init(&(lockarray[i]),NULL);
+    }
+
+    CRYPTO_set_id_callback((unsigned long (*)())thread_id);
+    CRYPTO_set_locking_callback((void (*)(int, int, const char*, int))lock_callback);
+
+    // initialize cipher and digest lookup functions
+    OpenSSL_add_all_algorithms();
+    // initialize the error strings
+    ERR_load_crypto_strings();
+
+}
+
+void deinit_openssl(void)
+{
+    int i;
+
+    // free lock array
+    CRYPTO_set_locking_callback(NULL);
+    for (i=0; i<CRYPTO_num_locks(); i++)
+        pthread_mutex_destroy(&(lockarray[i]));
+
+    OPENSSL_free(lockarray);
+
+    // de-initialisation ciphers and digests lookup functions
+    EVP_cleanup();
+    // free all previously loaded error strings
+    ERR_free_strings();
+}
 
 namespace fs = boost::filesystem;
 
@@ -101,8 +163,6 @@ namespace smime {
 
         int flags = PKCS7_DETACHED | PKCS7_STREAM | PKCS7_PARTIAL;
 
-        OpenSSL_add_all_algorithms();
-        ERR_load_crypto_strings();
 
         /* S/MIME certificate
          *

--- a/src/smime.h
+++ b/src/smime.h
@@ -21,6 +21,9 @@
 #include <vector>
 #include <boost/algorithm/string.hpp>
 
+void init_openssl(void);
+void deinit_openssl(void);
+
 namespace smime {
     using boost::split;
     using boost::trim;


### PR DESCRIPTION
make sigh thread save by moving the OpenSSL_add_all_algorithms() and ERR_load_crypto_strings() calls to an init function as well as adding the CRYPTO_set_id_callback and CRYPTO_set_locking_callback functions to the init function