### PR TITLE
#include <netinet/in.h> to improve portability, as sockaddr_in formally needs it.

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -12,6 +12,7 @@
 #define SRC_CLIENT_H_
 
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netdb.h>
 
 #include <string>


### PR DESCRIPTION
sockaddr_in formally needs #include <netinet/in.h> not only #include <sys/socket.h>
This also fixes a compile-time error on FreeBSD.